### PR TITLE
Add a block.json file

### DIFF
--- a/block.json
+++ b/block.json
@@ -1,0 +1,40 @@
+{
+	"name": "pdf-viewer-block/standard",
+	"title": "PDF Viewer",
+	"category": "embed",
+	"icon": "media-document",
+	"description": "A block to embed a PDF Viewer.",
+	"keywords": [ "pdf", "viewer", "reader" ],
+	"textDomain": "pdf-viewer-block",
+	"attributes": {
+		"mediaID": {
+			"type": "number"
+		},
+		"mediaURL": {
+			"type": "string",
+			"source": "attribute",
+			"selector": "a",
+			"attribute": "href"
+		},
+		"mediaWidth": {
+			"type": "string",
+			"source": "attribute",
+			"selector": "a",
+			"attribute": "data-width"
+		},
+		"mediaHeight": {
+			"type": "string",
+			"source": "attribute",
+			"selector": "a",
+			"attribute": "data-height"
+		},
+		"alignment": {
+			"type": "string",
+			"default": "left"
+		}
+	},
+	"editorScript": "admin/js/block.js",
+	"script": "public/js/pdf-viewer-block.js",
+	"editorStyle": "admin/css/admin.css",
+	"style": "public/css/pdf-viewer-block.css"
+}


### PR DESCRIPTION
This will help the plugin directory [find the correct block asset files](https://meta.trac.wordpress.org/ticket/5207#comment:7) so they can be available to the block inserter. It also helps this block plugin conform to the [Block Directory guidelines](https://github.com/WordPress/wporg-plugin-guidelines/blob/block-guidelines/blocks.md#4-block-plugins-must-include-a-blockjson-file).